### PR TITLE
Add English translation to "New Project", "Load Project" and "Save Pr…

### DIFF
--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -7,7 +7,9 @@ function Strings( config ) {
 		en: {
 
 			'menubar/file': 'File',
-			'menubar/file/new': 'New',
+			"menubar/file/new": 'New Project',
+			"menubar/file/load": 'Load Project',
+			"menubar/file/save": 'Save Project,
 			'menubar/file/import': 'Import',
 			'menubar/file/export/geometry': 'Export Geometry',
 			'menubar/file/export/object': 'Export Object',


### PR DESCRIPTION
Change translation "New" to "New Project" and add "Load Project" and "Save Project". 
French and Chinese translations would be missing.
![translations_menu](https://user-images.githubusercontent.com/560807/96030830-cf24af00-0e5c-11eb-9a2e-4797f5fe5302.jpg)
